### PR TITLE
Add diagnostic updater dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -57,6 +57,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>builtin_interfaces</depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
I built ros2 foxy from source and overlaid my environment with new workspace.
When I built autoware project using this package, I faced the following build error.
```console
Starting >>> dio_ros_driver
--- stderr: dio_ros_driver                                                                                                                                               
In file included from /home/autoware/autoware.proj/src/vendor/dio_ros_driver/include/dio_ros_driver/dio_ros_driver.hpp:39,
                 from /home/autoware/autoware.proj/src/vendor/dio_ros_driver/src/dio_ros_driver_node.cpp:26:
/home/autoware/autoware.proj/src/vendor/dio_ros_driver/include/dio_ros_driver/dio_diagnostic_updater.hpp:27:10: fatal error: diagnostic_updater/diagnostic_updater.hpp: No such file or directory
   27 | #include <diagnostic_updater/diagnostic_updater.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/dio_ros_driver_node.dir/build.make:63: CMakeFiles/dio_ros_driver_node.dir/src/dio_ros_driver_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:124: CMakeFiles/dio_ros_driver_node.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
Failed   <<< dio_ros_driver [21.0s, exited with code 2]
```
Looks like missing the dependency to `diagnostic_updater` in `package.xml`.

Procedures as follows:
refs: [Building ROS 2 on Ubuntu Linux](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html)

1. [Add the ROS 2 apt repository](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html#add-the-ros-2-apt-repository)
2. [Install development tools and ROS tools](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html#install-development-tools-and-ros-tools)
3. [Get ROS 2 code](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html#get-ros-2-code)
4. [Install dependencies using rosdep](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html#install-dependencies-using-rosdep)
5. Add diagnostics.git repository to `ros2_foxy/ros2.repos`.
```yaml
  dignostics:
    type: git
    url: https://github.com/ros/diagnostics.git
    version: foxy
```
6. [Build the code in the workspace](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html#build-the-code-in-the-workspace)
7. [Source the setup script](https://docs.ros.org/en/foxy/Installation/Ubuntu-Development-Setup.html#source-the-setup-script)
8. Remove `autoware.proj/build` & `autoware.proj/install`, then buiild autoware.
