### PR TITLE
remove mutex

### DIFF
--- a/include/dio_ros_driver/dio_ros_driver.hpp
+++ b/include/dio_ros_driver/dio_ros_driver.hpp
@@ -31,7 +31,6 @@
 #include <cstdint>
 #include <array>
 #include <vector>
-#include <mutex>
 #include <memory>
 
 #include "dio_ros_driver/din_accessor.hpp"
@@ -88,7 +87,6 @@ class DIO_ROSDriver : public rclcpp::Node {
   bool dout_default_value_;  // !<@brief DOUT defaule value
 
   // variable for sharing between callbacks
-  std::mutex write_update_mutex_;                           // !<@brief mutex.
   std::array<dout_update, MAX_PORT_NUM> dout_user_update_;  // !<@brief update list.
   gpiod_chip *dio_chip_;                                    // !<@brief chip descriptor
 };


### PR DESCRIPTION
mutexがあると、正常に終了しない場合がある。
nodeがmutex取得中にsigtermが来ると、terminate内部でmutexを取れずに固まって可能性があります。
そこで本nodeはsingle threadでのみ動作で、mutexは不要なため削除しました。
