### PR TITLE
Add libgpiod-dev to packages.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -59,6 +59,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>builtin_interfaces</depend>
+  <depend>libgpiod-dev</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
##
 - rosdepでビルドに必要な依存ライブラリが入るようにpackage.xmlにdependを追加します。
   - libgpiod-dev
